### PR TITLE
[BUGFIX] rename 'hooks' to avoid dependency clash

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -21,7 +21,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require_dependency 'hooks'
+require_dependency 'autowatch_hooks'
 
 Redmine::Plugin.register :autowatch do
   name 'AutoWatch plugin'

--- a/lib/autowatch_hooks.rb
+++ b/lib/autowatch_hooks.rb
@@ -21,7 +21,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-class Hooks < Redmine::Hook::ViewListener
+class AutowatchHooks < Redmine::Hook::ViewListener
   def controller_issues_new_before_save(context={})
     autowatch_role_id = Setting.plugin_autowatch['role_id'].to_i
     return if autowatch_role_id == 0


### PR DESCRIPTION
as other plugins also use `require_dependency 'hooks'`, using autowatch with other plugins can cause problems as the dependencies overrule each other